### PR TITLE
Fix errors, reduce image size, add convenient commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+mnt
+cached

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ RUN cd athena && \
   tar -xzf athena-linux.tar.gz
 ENV ATHENA_HOME /athena
 ENV PATH /athena/:$PATH
-RUN touch minisat_out.txt
+RUN touch athena/minisat_out.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ RUN apt-get update \
     wget vim
 
 RUN mkdir athena
-RUN cd ./athena
-RUN wget -O athena-linux.tar.gz http://proofcentral.org/athena/1.4/resources/athena-linux.tar.gz
-RUN tar -xzf athena-linux.tar.gz
-RUN export ATHENA_HOME=$PWD
+RUN cd athena && \
+  wget -O athena-linux.tar.gz http://proofcentral.org/athena/1.4/resources/athena-linux.tar.gz && \
+  tar -xzf athena-linux.tar.gz
+ENV ATHENA_HOME /athena
+ENV PATH /athena/:$PATH
+RUN touch minisat_out.txt
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,28 @@
-image: Dockerfile
-	sudo docker build -t athena-image .
+ATH_FILE ?= test.ath
+
+all: image run
+
+image: Dockerfile mount-dir
+	docker build -t athena-image .
 
 run:
-	sudo docker run -it -v $(PWD)/mnt:/mnt athena-image:latest bash
+	docker run --name athena-container -t -d -v $(PWD)/mnt:/mnt athena-image:latest bash
+
+run-interactive:
+	docker run --name athena-container -it -v $(PWD)/mnt:/mnt athena-image:latest bash
+
+check-athena: test.ath
+
+mount-dir:
+	mkdir ./mnt && echo 'module TestFile {\ndomain Person\n}' > ./mnt/test.ath
+
+clean:
+	docker container stop athena-container && \
+	docker container rm athena-container && \
+	docker image rm athena-image && \
+	mkdir saved && \
+	cp -r mnt/ cached/ && \
+	rm -rf mnt
+
+%.ath:
+	docker container exec athena-container athena /mnt/$@

--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
-# docker-env-athena
+# Dockerized Environment for Athena
 
-To prepare Docker image: `make image`
+# Usage Instructions
 
-To run it: `make run`
+## Pre-requisites
+Ensure that docker is installed. After installing docker, ensure that you have created a `docker` group and that you've added yourself to the docker group. Instructions for setting up docker permissions can be found [here](https://docs.docker.com/engine/install/linux-postinstall/). Doing this will allow you to run the Athena container without `sudo` and to be able to utilize the `mnt` directory.
 
-The `mnt/` directory inside the container corresponds to the `mnt/` directory of this repository.
+## Usage
+
+### Setup
+
+To prepare the docker image and run it in the background, use `make all`.
+
+To ensure that athena is working, use `make check-athena`.
+
+### Run new athena file
+You can add new `.ath` files to the `mnt` directory. When you do so, you can run `make <file_name>.ath`.
+
+### Shutdown
+
+To stop the container, clean up the image, and remove the `mnt` directory, you can do `make clean`. This will also create a new directory in the root dir of this repository called `cached` and will copy the files in the `mnt` directory to `cached` so you do not accidentally lose your work. 
+
+
+### Misc
+
+*Build image without running*: `make image`
+*Run container without rebuilding image*: `make run`
+*Run the container in interactive mode*: `make run-interactive`
+*Rebuild mount directory after deleting*: `make mount-dir`


### PR DESCRIPTION
In the previous setup, athena was not actually executing after the container was started. This was due the athena binary not existing in the container's PATH variable. Further, the dockerfile's command to set the ATHENA_HOME env var only persisted for the duration of the image build stage (it needed to be set after container startup as well). The `sudo` commands in Makefile also caused some problems, where writing to or opening the `mnt` directory required admin privileges. This caused problems running athena in the container because it could not access those files.

Changes in this PR:
1. Ensure env vars & PATH are set properly upon container startup
2. Reduce the size of intermediate images by changing the Dockerfile
3. Add `make all` for building image & running container in one step
4. Add general `make` command for running any athena file located in the mount directory
5. Change README to point to post-installation instructions for Docker so that `sudo` is not required (as well as removed use of `sudo` in the makefile)
6. Add `make clean` to shut down the container, delete image, and clear mount directory contents (also caches files in mount directory inside a `cached` dir)

